### PR TITLE
ci: replace Travis with GitHub Actions, add go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.23', 'stable']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - run: go vet ./...
+      - run: go test ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: go
-
-go:
-  - "stable"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/csvj-org/gocsvj
+
+go 1.23


### PR DESCRIPTION
## Summary

Replaces the dead `.travis.yml` (Travis CI has not been usable on this repo
for a long while) with a minimal GitHub Actions workflow. Adds `go.mod` so
the workflow can run modern, module-aware Go tooling — the repo had been
relying on GOPATH-style layout. No external dependencies are needed, so
the module file lists none.

## Workflow

- Triggers on push to `master` and on every PR.
- Matrix: Go `1.23` and `stable`.
- Steps: `go vet ./...` and `go test ./...`.
- Third-party actions (`actions/checkout`, `actions/setup-go`) use tag refs
  for now. SHA-pinning is deferred until Dependabot is configured in a
  follow-up, to avoid creating tag-revert dependabot churn before then.
- `golangci-lint`, mentioned in PLAN.md §5, is deferred to a follow-up PR
  to keep this change purely additive (no existing-code adjustments).

## Test plan

- [x] `go vet ./...` locally — clean.
- [x] `go test ./...` locally — both `gocsvj` and `gocsvj/lint` pass.
- [ ] GitHub Actions matrix turns green on this PR.

Refs PLAN.md §5 (Replace `.travis.yml` with `.github/workflows/ci.yml`).