### PR TITLE
ci: add dependabot config for gomod and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - go
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to track weekly updates for Go modules and GitHub Actions.
- Pairs with the upcoming SHA-pin sweep (PLAN.md §5): once `actions/checkout` and `actions/setup-go` in `ci.yml` are pinned to commit SHAs, Dependabot will continue to bump them.

## Test plan

- [x] `go test ./...` clean.
- [x] `go vet ./...` clean.
- [ ] After merge, confirm Dependabot picks up the config (Insights → Dependency graph → Dependabot tab on the repo).