### PR TITLE
SHA-pin third-party actions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         go: ['1.23', 'stable']
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ matrix.go }}
       - run: go vet ./...


### PR DESCRIPTION
## Summary

- Pin `actions/checkout` and `actions/setup-go` to commit SHAs with the release tag retained as a trailing comment.
- Dependabot continues to track updates via the `# vN` comment; per the ralph-loop tag-revert rule, tag-form bumps that would revert these pins will be closed with a pointer back to this PR.

PLAN.md §5 task: "SHA-pin all third-party actions in workflows (after Dependabot is set up to track them)".

## Test plan

- [ ] CI green on both Go versions (`1.23` and `stable`) — same as master.
- [ ] Confirm the next Dependabot run produces SHA-form bumps, not tag-reverts.