### PR TITLE
docs: seed CHANGELOG.md and add CI + Go reference badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+aims to use [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once
+a first tagged release is cut.
+
+## [Unreleased]
+
+### Added
+- GitHub Actions CI workflow (`.github/workflows/ci.yml`) running `go vet`
+  and `go test` on a matrix of Go 1.23 and stable.
+- Dependabot configuration (`.github/dependabot.yml`) covering both Go
+  modules and GitHub Actions.
+- `go.mod` declaring the module path `github.com/csvj-org/gocsvj` and
+  Go 1.23 as the minimum.
+
+### Changed
+- Third-party GitHub Actions in the CI workflow are now SHA-pinned with
+  the tag preserved as a trailing comment.
+
+### Removed
+- `.travis.yml` — Travis CI is no longer used.
+
+## 2018-10-29 — Initial reference implementation
+
+Unreleased / untagged. The history before 2026 is preserved here for
+reference; the public module path and tagged versions begin with the
+first entry under [Unreleased].
+
+### Added
+- `reader.go` and `reader_test.go` — streaming reader for CSVJ files.
+- `writer.go` and `writer_test.go` — writer producing spec-compliant
+  output.
+- `lint/` package and `csvj-cmd/` command-line linter.
+- MIT LICENSE and initial README.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # gocsvj
 
+[![CI](https://github.com/csvj-org/gocsvj/actions/workflows/ci.yml/badge.svg)](https://github.com/csvj-org/gocsvj/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/csvj-org/gocsvj.svg)](https://pkg.go.dev/github.com/csvj-org/gocsvj)
+
 Package to work with [CSVJ](https://csvj.org) files with golang
 
 Also contains command-line tool csvj-cmd which at the moment can lint CSVJ files
-
-


### PR DESCRIPTION
## Summary
- Adds `CHANGELOG.md` in Keep-a-Changelog format. The Unreleased section
  captures the 2026-05-26 CI/dependabot/SHA-pin landings; a historical
  section preserves the 2018 initial reference implementation.
- Adds two badges to the README: CI status (linking to the GHA workflow
  added in #3) and Go reference (linking to pkg.go.dev).
- Bundles the two PLAN.md §5 hygiene items that are not blocked. `SECURITY.md`
  is intentionally deferred — it needs §6a's "enable Private Vulnerability
  Reporting" operator step first so the file can point at the Security
  tab's report button rather than an ad-hoc email.

No code or workflow changes. Per the self-merge policy, this is "agent-authored
mechanical fixes that do NOT touch normative content" — squash-merge after CI.

## Test plan
- [x] `go test ./...` — pass
- [x] `go vet ./...` — pass
- [ ] CI workflow runs green on this PR