### PR TITLE
test: broaden reader/writer coverage for spec corners

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -175,3 +175,207 @@ func TestReaderEmptyError(t *testing.T) {
 		t.Error("expected error, but none returned")
 	}
 }
+
+// The tests below cover spec corners that are already pinned down (RFC 8259
+// lexical rules and existing reader behavior). They exercise behavior the
+// reader already supports; they intentionally do not assert on the §1
+// structural rules tracked separately in PLAN.md §5 (strict §1 enforcement).
+
+func TestReaderUTF8Values(t *testing.T) {
+	csvj := `"Header1", "Header2", "Header3"` + "\n"
+	csvj += `"héllo", "日本語", "🚀"` + "\n"
+
+	r := NewReader(strings.NewReader(csvj))
+
+	_, err := r.Headers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	row, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	erow := []interface{}{"héllo", "日本語", "🚀"}
+	if !reflect.DeepEqual(row, erow) {
+		t.Error("Bad Row", row, "expected", erow)
+	}
+}
+
+func TestReaderCRLFLineEndings(t *testing.T) {
+	csvj := `"h1", "h2", "h3"` + "\r\n"
+	csvj += `1, 2, 3` + "\r\n"
+
+	r := NewReader(strings.NewReader(csvj))
+
+	hdr, err := r.Headers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(hdr, []string{"h1", "h2", "h3"}) {
+		t.Error("Unexpected Header", hdr)
+	}
+
+	row, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	erow := []interface{}{1.0, 2.0, 3.0}
+	if !reflect.DeepEqual(row, erow) {
+		t.Error("Bad Row", row, "expected", erow)
+	}
+}
+
+func TestReaderJSONStringEscapes(t *testing.T) {
+	csvj := `"Header1", "Header2", "Header3", "Header4"` + "\n"
+	csvj += `"line1\nline2", "tab\there", "quote\"end", "backslash\\"` + "\n"
+
+	r := NewReader(strings.NewReader(csvj))
+
+	_, err := r.Headers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	row, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	erow := []interface{}{"line1\nline2", "tab\there", `quote"end`, `backslash\`}
+	if !reflect.DeepEqual(row, erow) {
+		t.Error("Bad Row", row, "expected", erow)
+	}
+}
+
+func TestReaderUnicodeEscape(t *testing.T) {
+	// RFC 8259 \uXXXX form, including a surrogate pair encoding U+1F600.
+	// Raw-string literals keep the backslashes intact so the JSON layer
+	// (not Go's lexer) is what resolves the escapes.
+	csvj := `"Header1", "Header2"` + "\n"
+	csvj += `"\u00e9", "\uD83D\uDE00"` + "\n"
+
+	r := NewReader(strings.NewReader(csvj))
+
+	_, err := r.Headers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	row, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	erow := []interface{}{"é", "😀"}
+	if !reflect.DeepEqual(row, erow) {
+		t.Error("Bad Row", row, "expected", erow)
+	}
+}
+
+func TestReaderNumberForms(t *testing.T) {
+	csvj := `"h1", "h2", "h3", "h4", "h5"` + "\n"
+	csvj += `-1, 0, 1.5, 1e10, -2.5e-3` + "\n"
+
+	r := NewReader(strings.NewReader(csvj))
+
+	_, err := r.Headers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	row, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	erow := []interface{}{-1.0, 0.0, 1.5, 1e10, -2.5e-3}
+	if !reflect.DeepEqual(row, erow) {
+		t.Error("Bad Row", row, "expected", erow)
+	}
+}
+
+func TestReaderBooleansAndNull(t *testing.T) {
+	csvj := `"h1", "h2", "h3", "h4"` + "\n"
+	csvj += `true, false, null, "string"` + "\n"
+
+	r := NewReader(strings.NewReader(csvj))
+
+	_, err := r.Headers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	row, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	erow := []interface{}{true, false, nil, "string"}
+	if !reflect.DeepEqual(row, erow) {
+		t.Error("Bad Row", row, "expected", erow)
+	}
+}
+
+func TestReaderMultipleRows(t *testing.T) {
+	csvj := `"h1", "h2"` + "\n"
+	csvj += `1, 2` + "\n"
+	csvj += `3, 4` + "\n"
+	csvj += `5, 6` + "\n"
+
+	r := NewReader(strings.NewReader(csvj))
+
+	_, err := r.Headers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := [][]interface{}{
+		{1.0, 2.0},
+		{3.0, 4.0},
+		{5.0, 6.0},
+	}
+	for i, erow := range expected {
+		row, err := r.Read()
+		if err != nil {
+			t.Fatalf("row %d: %v", i, err)
+		}
+		if !reflect.DeepEqual(row, erow) {
+			t.Errorf("row %d: got %v, expected %v", i, row, erow)
+		}
+	}
+	if _, eofErr := r.Read(); eofErr != io.EOF {
+		t.Error("EOF expected after final row, got", eofErr)
+	}
+}
+
+func TestReaderLongValue(t *testing.T) {
+	// 4 KiB string value — well under bufio.Scanner's default 64 KiB limit
+	// and well above any value that would be inlined in normal CSV data.
+	longValue := strings.Repeat("a", 4096)
+	csvj := `"h1"` + "\n"
+	csvj += `"` + longValue + `"` + "\n"
+
+	r := NewReader(strings.NewReader(csvj))
+
+	_, err := r.Headers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	row, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(row) != 1 {
+		t.Fatalf("expected 1 column, got %d", len(row))
+	}
+	got, ok := row[0].(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", row[0])
+	}
+	if got != longValue {
+		t.Error("long value did not round-trip")
+	}
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,6 +1,7 @@
 package gocsvj
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -85,5 +86,174 @@ func TestWriteNonCSVJ(t *testing.T) {
 
 	if err == nil {
 		t.Error("Expected error, but none returned")
+	}
+}
+
+// The tests below cover writer corners that are already pinned down (RFC 8259
+// escape rules and existing writer behavior).
+
+func TestWriterUTF8Values(t *testing.T) {
+	var sw strings.Builder
+	w := NewWriter(&sw)
+
+	w.WriteHeader([]string{"h1", "h2", "h3"})
+	if err := w.Write([]interface{}{"héllo", "日本語", "🚀"}); err != nil {
+		t.Fatal(err)
+	}
+	w.Flush()
+
+	if !strings.Contains(sw.String(), `"héllo"`) {
+		t.Error("UTF-8 string not preserved in output:", sw.String())
+	}
+	if !strings.Contains(sw.String(), `"日本語"`) {
+		t.Error("UTF-8 string not preserved in output:", sw.String())
+	}
+}
+
+func TestWriterRoundTripUTF8(t *testing.T) {
+	var sw strings.Builder
+	w := NewWriter(&sw)
+
+	w.WriteHeader([]string{"h1", "h2", "h3"})
+	if err := w.Write([]interface{}{"héllo", "日本語", "🚀"}); err != nil {
+		t.Fatal(err)
+	}
+	w.Flush()
+
+	r := NewReader(strings.NewReader(sw.String()))
+	hdr, err := r.Headers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(hdr, []string{"h1", "h2", "h3"}) {
+		t.Error("header round-trip mismatch:", hdr)
+	}
+
+	row, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	erow := []interface{}{"héllo", "日本語", "🚀"}
+	if !reflect.DeepEqual(row, erow) {
+		t.Error("Bad Row", row, "expected", erow)
+	}
+}
+
+func TestWriterStringEscapes(t *testing.T) {
+	var sw strings.Builder
+	w := NewWriter(&sw)
+
+	w.WriteHeader([]string{"h1", "h2", "h3"})
+	if err := w.Write([]interface{}{`line1` + "\n" + `line2`, `quote"end`, `back\slash`}); err != nil {
+		t.Fatal(err)
+	}
+	w.Flush()
+
+	r := NewReader(strings.NewReader(sw.String()))
+	if _, err := r.Headers(); err != nil {
+		t.Fatal(err)
+	}
+	row, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	erow := []interface{}{"line1\nline2", `quote"end`, `back\slash`}
+	if !reflect.DeepEqual(row, erow) {
+		t.Error("Bad Row", row, "expected", erow)
+	}
+}
+
+func TestWriterNumberTypes(t *testing.T) {
+	var sw strings.Builder
+	w := NewWriter(&sw)
+
+	w.WriteHeader([]string{"h1", "h2", "h3", "h4"})
+	if err := w.Write([]interface{}{-1, 0, 1.5, -2.5}); err != nil {
+		t.Fatal(err)
+	}
+	w.Flush()
+
+	r := NewReader(strings.NewReader(sw.String()))
+	if _, err := r.Headers(); err != nil {
+		t.Fatal(err)
+	}
+	row, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	erow := []interface{}{-1.0, 0.0, 1.5, -2.5}
+	if !reflect.DeepEqual(row, erow) {
+		t.Error("Bad Row", row, "expected", erow)
+	}
+}
+
+func TestWriterBooleans(t *testing.T) {
+	var sw strings.Builder
+	w := NewWriter(&sw)
+
+	w.WriteHeader([]string{"h1", "h2"})
+	if err := w.Write([]interface{}{true, false}); err != nil {
+		t.Fatal(err)
+	}
+	w.Flush()
+
+	r := NewReader(strings.NewReader(sw.String()))
+	if _, err := r.Headers(); err != nil {
+		t.Fatal(err)
+	}
+	row, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	erow := []interface{}{true, false}
+	if !reflect.DeepEqual(row, erow) {
+		t.Error("Bad Row", row, "expected", erow)
+	}
+}
+
+func TestWriterMultipleRows(t *testing.T) {
+	var sw strings.Builder
+	w := NewWriter(&sw)
+
+	w.WriteHeader([]string{"h1", "h2"})
+	for _, rec := range [][]int{{1, 2}, {3, 4}, {5, 6}} {
+		if err := w.Write(rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	w.Flush()
+
+	r := NewReader(strings.NewReader(sw.String()))
+	if _, err := r.Headers(); err != nil {
+		t.Fatal(err)
+	}
+	expected := [][]interface{}{
+		{1.0, 2.0},
+		{3.0, 4.0},
+		{5.0, 6.0},
+	}
+	for i, erow := range expected {
+		row, err := r.Read()
+		if err != nil {
+			t.Fatalf("row %d: %v", i, err)
+		}
+		if !reflect.DeepEqual(row, erow) {
+			t.Errorf("row %d: got %v, expected %v", i, row, erow)
+		}
+	}
+}
+
+func TestWriterNonStrictHeaderLength(t *testing.T) {
+	// With StrictHeaders disabled the writer should accept rows whose length
+	// does not match the header. (Spec-wise this produces a ragged file —
+	// the conformance work in PLAN.md §5 may invert that later, but the
+	// writer's own StrictHeaders=false escape hatch should keep working.)
+	var sw strings.Builder
+	w := NewWriter(&sw)
+	w.StrictHeaders = false
+
+	w.WriteHeader([]string{"h1", "h2", "h3"})
+	if err := w.Write([]int{1, 2}); err != nil {
+		t.Error("Unexpected error with StrictHeaders=false:", err)
 	}
 }


### PR DESCRIPTION
## Summary

Behavior-preserving test additions covering RFC 8259 lexical rules and reader/writer behavior that the spec has already pinned down. No changes to `reader.go`, `writer.go`, or `lint/` — this is test-only.

PLAN.md §5 → ["Broaden test coverage for spec corners already pinned down"](https://github.com/csvj-org/gocsvj/blob/master/.. (see project PLAN.md)).

## Reader tests added

- UTF-8 multi-byte values
- CRLF line endings
- JSON string escapes (`\n`, `\t`, `\"`, `\\`)
- `\uXXXX` escapes including a surrogate pair (U+1F600)
- Number forms (negative, scientific, decimal)
- Booleans and `null`
- Multiple rows
- 4 KiB string value (well under `bufio.Scanner`'s default limit)

## Writer tests added

- UTF-8 multi-byte values
- Reader/writer round-trip for UTF-8
- String escape sequences (newline, quote, backslash)
- Number types (int and float, including negative)
- Booleans
- Multiple sequential writes
- `StrictHeaders=false` escape hatch

## Out of scope

None of these depend on the strict-§1 reader behavior tracked separately in PLAN.md §5. The structural rules whose enforcement is still open (single-`\n` accept, trailing-newline reject, ragged-row reject, duplicate-header reject) are intentionally not covered here — they will land with the strict-§1 PR.

## Test plan

- [x] `go test ./...` — all 31 tests pass (16 reader, 12 writer, 3 lint)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean