### PR TITLE
ci: run conformance suite against this PR's gocsvj

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,24 @@ jobs:
           go-version: ${{ matrix.go }}
       - run: go vet ./...
       - run: go test ./...
+
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: gocsvj
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: csvj-org/conformance
+          ref: master
+          path: conformance
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: 'stable'
+      - name: Point conformance suite at this PR's gocsvj
+        working-directory: conformance
+        run: go mod edit -replace github.com/csvj-org/gocsvj=../gocsvj
+      - name: Run conformance suite
+        working-directory: conformance
+        run: go test ./...


### PR DESCRIPTION
## Summary

Adds a `conformance` job to the CI workflow that runs the
[csvj-org/conformance](https://github.com/csvj-org/conformance) vectors
against the PR's gocsvj source. The job:

1. Checks out gocsvj into `./gocsvj`.
2. Checks out `csvj-org/conformance@master` into `./conformance`.
3. Runs `go mod edit -replace github.com/csvj-org/gocsvj=../gocsvj` inside
   `./conformance` so the suite tests the PR's code, not the latest tagged
   gocsvj.
4. Runs `go test ./...` in the conformance directory.

Catches behavior drift between gocsvj and the published conformance vectors
before a PR merges. Closes the §5 "Add the conformance suite as a CI step"
TODO in PLAN.md (and the matching §2 TODO).

## Test plan

- [x] Conformance suite passes locally against `gocsvj@master` (4 input
  vectors + 4 must-reject vectors).
- [ ] CI run on this PR comes back green.

## Notes

- New job runs on stable Go only; the matrix on the existing `test` job
  already covers Go version sensitivity for gocsvj itself.
- SHA-pinned `actions/checkout` and `actions/setup-go` at the same v6
  pins already used by the `test` job.
- Tracks `csvj-org/conformance@master`. If a new conformance PR lands a
  vector gocsvj does not yet pass, that gocsvj PR will go red until either
  gocsvj is fixed or the vector is added to the conformance
  `referencePending` skip-list — exactly the safety property the wiring
  is supposed to give us.